### PR TITLE
Add `default-channel` option and `exclude` constraint

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,8 @@
+[flake8]
+max-line-length = 120
+max-complexity = 10
+ignore = W503, E712, E231, E203
+exclude = .git,__pycache__,.venv, .env
+count = True
+show-source = True
+statistics = True

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -4,49 +4,28 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
-        python: [3.6, 3.7, 3.8]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python: [3.7, 3.8, 3.9]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Setup Python ${{ matrix.python }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python }}
 
-      - name: Install
-        env:
-          # Python-related environment variables
-          PYTHONUNBUFFERED: "1"
-          # prevents python creating .pyc files
-          PYTHONDONTWRITEBYTECODE: "1"
-          # pip-related environment variables
-          PIP_NO_CACHE_DIR: "off"
-          PIP_DISABLE_PIP_VERSION_CHECK: "on"
-          PIP_DEFAULT_TIMEOUT: "100"
-          PIP_VERSION: "20.0.2"
-          # poetry-related environment variables
-          # https://python-poetry.org/docs/configuration/#using-environment-variables
-          POETRY_VERSION: "1.0.5"
-          # make poetry install to this location
-          POETRY_HOME: "/opt/poetry"
-          # make poetry create the virtual environment in the project's root
-          # it gets named `.venv`
-          POETRY_VIRTUALENVS_IN_PROJECT: "true"
-          # do not ask any interactive question
-          POETRY_NO_INTERACTION: "1"
-          # paths-related environment variables
-          # this is where our requirements + virtual environment will live
-          PYSETUP_PATH: "/opt/pysetup"
-          VENV_PATH: "/opt/pysetup/.venv"
+      - name: Install poetry
         run: |
-          curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
-          export PATH="$POETRY_HOME/bin:$VENV_PATH/bin:$PATH"
-          poetry install
+          python -m pip install --upgrade pip
+          pip install poetry
+
+      - name: Install
+        run: poetry install
+
+      - name: Lint
+        run: poetry run flake8 .
 
       - name: Unit tests
-        run: |
-          source .venv/bin/activate
-          pytest -v
+        run: poetry run pytest

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ collaborators that prefer regular Python/PyPI and others that prefer conda.
 Features
 --------
 
-- Set conda channels for each dependency.
+- Set conda channels globally or for each dependency.
 - Rename conda dependencies.
 - Exclude conda dependencies.
 - Convert tilde and caret dependencies to regular version specifiers.
@@ -150,6 +150,29 @@ Which would give:
 .. code-block:: yaml
 
     name: example-with-pip
+    dependencies:
+      - pip
+      - pip:
+        - quetzal-client>=0.5.2,<0.6.0
+
+You can also default all of your packages to be pulled from a specific channel:
+
+.. code-block:: toml
+
+
+    [tool.poetry.dependencies]
+    quetzal-client = "^0.5.2"
+    # ...
+
+    [tool.poetry2conda]
+    name = "example-default-pip"
+    default-channel = "pip"
+
+Which would give:
+
+.. code-block:: yaml
+
+    name: example-default-pip
     dependencies:
       - pip
       - pip:

--- a/README.rst
+++ b/README.rst
@@ -21,6 +21,7 @@ Features
 
 - Set conda channels for each dependency.
 - Rename conda dependencies.
+- Exclude conda dependencies.
 - Convert tilde and caret dependencies to regular version specifiers.
 - Handle pure pip dependencies.
 
@@ -222,6 +223,20 @@ Which will be translated to:
     name: strange-example
     dependencies:
       - conda-forge::bob>=2.3.0,<3.0.0
+
+Sometimes, you may just want to exclude a dependency from conda. For this case, declare it as follows:
+
+.. code-block:: toml
+
+    [tool.poetry.dependencies]
+    foo = "^1.2.3"
+    # ...
+
+    [tool.poetry2conda]
+    name = "my-env-with-channels"
+
+    [tool.poetry2conda.dependencies]
+    foo = { exclude = true }
 
 
 Contribute

--- a/poetry.lock
+++ b/poetry.lock
@@ -76,6 +76,20 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
 toml = ["toml"]
 
 [[package]]
+name = "flake8"
+version = "4.0.1"
+description = "the modular source code checker: pep8 pyflakes and co"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+importlib-metadata = {version = "<4.3", markers = "python_version < \"3.8\""}
+mccabe = ">=0.6.0,<0.7.0"
+pycodestyle = ">=2.8.0,<2.9.0"
+pyflakes = ">=2.4.0,<2.5.0"
+
+[[package]]
 name = "importlib-metadata"
 version = "1.6.0"
 description = "Read metadata from Python packages"
@@ -89,6 +103,14 @@ zipp = ">=0.5"
 [package.extras]
 docs = ["sphinx", "rst.linker"]
 testing = ["packaging", "importlib-resources"]
+
+[[package]]
+name = "mccabe"
+version = "0.6.1"
+description = "McCabe checker, plugin for flake8"
+category = "dev"
+optional = false
+python-versions = "*"
 
 [[package]]
 name = "more-itertools"
@@ -144,6 +166,22 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 name = "py"
 version = "1.8.1"
 description = "library with cross-python path, ini-parsing, io, code, log facilities"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "pycodestyle"
+version = "2.8.0"
+description = "Python style guide checker"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "pyflakes"
+version = "2.4.0"
+description = "passive checker of Python programs"
 category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
@@ -271,7 +309,7 @@ testing = ["jaraco.itertools", "func-timeout"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "ab7627624a7f34ea86ae4e2a338a094ddfa9ebbe4c376f13851abef8ae72af05"
+content-hash = "a35136646524e98220a6949b5d5c803d55123db5201e191470d4a09c9bffe032"
 
 [metadata.files]
 appdirs = [
@@ -331,9 +369,17 @@ coverage = [
     {file = "coverage-5.1-cp39-cp39-win_amd64.whl", hash = "sha256:bb28a7245de68bf29f6fb199545d072d1036a1917dca17a1e75bbb919e14ee8e"},
     {file = "coverage-5.1.tar.gz", hash = "sha256:f90bfc4ad18450c80b024036eaf91e4a246ae287701aaa88eaebebf150868052"},
 ]
+flake8 = [
+    {file = "flake8-4.0.1-py2.py3-none-any.whl", hash = "sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d"},
+    {file = "flake8-4.0.1.tar.gz", hash = "sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d"},
+]
 importlib-metadata = [
     {file = "importlib_metadata-1.6.0-py2.py3-none-any.whl", hash = "sha256:2a688cbaa90e0cc587f1df48bdc97a6eadccdcd9c35fb3f976a09e3b5016d90f"},
     {file = "importlib_metadata-1.6.0.tar.gz", hash = "sha256:34513a8a0c4962bc66d35b359558fd8a5e10cd472d37aec5f66858addef32c1e"},
+]
+mccabe = [
+    {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
+    {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
 ]
 more-itertools = [
     {file = "more-itertools-8.2.0.tar.gz", hash = "sha256:b1ddb932186d8a6ac451e1d95844b382f55e12686d51ca0c68b6f61f2ab7a507"},
@@ -358,6 +404,14 @@ poetry-semver = [
 py = [
     {file = "py-1.8.1-py2.py3-none-any.whl", hash = "sha256:c20fdd83a5dbc0af9efd622bee9a5564e278f6380fffcacc43ba6f43db2813b0"},
     {file = "py-1.8.1.tar.gz", hash = "sha256:5e27081401262157467ad6e7f851b7aa402c5852dbcb3dae06768434de5752aa"},
+]
+pycodestyle = [
+    {file = "pycodestyle-2.8.0-py2.py3-none-any.whl", hash = "sha256:720f8b39dde8b293825e7ff02c475f3077124006db4f440dcbc9a20b76548a20"},
+    {file = "pycodestyle-2.8.0.tar.gz", hash = "sha256:eddd5847ef438ea1c7870ca7eb78a9d47ce0cdb4851a5523949f2601d0cbbe7f"},
+]
+pyflakes = [
+    {file = "pyflakes-2.4.0-py2.py3-none-any.whl", hash = "sha256:3bb3a3f256f4b7968c9c788781e4ff07dce46bdf12339dcda61053375426ee2e"},
+    {file = "pyflakes-2.4.0.tar.gz", hash = "sha256:05a85c2872edf37a4ed30b0cce2f6093e1d0581f8c19d7393122da7e25b2b24c"},
 ]
 pyparsing = [
     {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,27 +1,26 @@
 [[package]]
-category = "dev"
-description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 name = "appdirs"
+version = "1.4.3"
+description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
+category = "dev"
 optional = false
 python-versions = "*"
-version = "1.4.3"
 
 [[package]]
-category = "dev"
-description = "Atomic file writes."
-marker = "sys_platform == \"win32\""
 name = "atomicwrites"
+version = "1.3.0"
+description = "Atomic file writes."
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "1.3.0"
 
 [[package]]
-category = "dev"
-description = "Classes Without Boilerplate"
 name = "attrs"
+version = "19.3.0"
+description = "Classes Without Boilerplate"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "19.3.0"
 
 [package.extras]
 azure-pipelines = ["coverage", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "pytest-azurepipelines"]
@@ -30,12 +29,12 @@ docs = ["sphinx", "zope.interface"]
 tests = ["coverage", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface"]
 
 [[package]]
-category = "dev"
-description = "The uncompromising code formatter."
 name = "black"
+version = "19.10b0"
+description = "The uncompromising code formatter."
+category = "dev"
 optional = false
 python-versions = ">=3.6"
-version = "19.10b0"
 
 [package.dependencies]
 appdirs = "*"
@@ -50,41 +49,39 @@ typed-ast = ">=1.4.0"
 d = ["aiohttp (>=3.3.2)", "aiohttp-cors"]
 
 [[package]]
-category = "dev"
-description = "Composable command line interface toolkit"
 name = "click"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 version = "7.1.1"
-
-[[package]]
+description = "Composable command line interface toolkit"
 category = "dev"
-description = "Cross-platform colored terminal text."
-marker = "sys_platform == \"win32\""
-name = "colorama"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "0.4.3"
 
 [[package]]
+name = "colorama"
+version = "0.4.3"
+description = "Cross-platform colored terminal text."
 category = "dev"
-description = "Code coverage measurement for Python"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
 name = "coverage"
+version = "5.1"
+description = "Code coverage measurement for Python"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
-version = "5.1"
 
 [package.extras]
 toml = ["toml"]
 
 [[package]]
-category = "dev"
-description = "Read metadata from Python packages"
-marker = "python_version < \"3.8\""
 name = "importlib-metadata"
+version = "1.6.0"
+description = "Read metadata from Python packages"
+category = "dev"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
-version = "1.6.0"
 
 [package.dependencies]
 zipp = ">=0.5"
@@ -94,121 +91,116 @@ docs = ["sphinx", "rst.linker"]
 testing = ["packaging", "importlib-resources"]
 
 [[package]]
-category = "dev"
-description = "More routines for operating on iterables, beyond itertools"
 name = "more-itertools"
+version = "8.2.0"
+description = "More routines for operating on iterables, beyond itertools"
+category = "dev"
 optional = false
 python-versions = ">=3.5"
-version = "8.2.0"
 
 [[package]]
-category = "dev"
-description = "Core utilities for Python packages"
 name = "packaging"
+version = "20.3"
+description = "Core utilities for Python packages"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "20.3"
 
 [package.dependencies]
 pyparsing = ">=2.0.2"
 six = "*"
 
 [[package]]
-category = "dev"
-description = "Utility library for gitignore style pattern matching of file paths."
 name = "pathspec"
+version = "0.8.0"
+description = "Utility library for gitignore style pattern matching of file paths."
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "0.8.0"
 
 [[package]]
-category = "dev"
-description = "plugin and hook calling mechanisms for python"
 name = "pluggy"
+version = "0.13.1"
+description = "plugin and hook calling mechanisms for python"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "0.13.1"
 
 [package.dependencies]
-[package.dependencies.importlib-metadata]
-python = "<3.8"
-version = ">=0.12"
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 
 [package.extras]
 dev = ["pre-commit", "tox"]
 
 [[package]]
-category = "main"
-description = "A semantic versioning library for Python"
 name = "poetry-semver"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "0.1.0"
-
-[[package]]
-category = "dev"
-description = "library with cross-python path, ini-parsing, io, code, log facilities"
-name = "py"
+description = "A semantic versioning library for Python"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "1.8.1"
 
 [[package]]
+name = "py"
+version = "1.8.1"
+description = "library with cross-python path, ini-parsing, io, code, log facilities"
 category = "dev"
-description = "Python parsing module"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
 name = "pyparsing"
+version = "2.4.7"
+description = "Python parsing module"
+category = "dev"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
-version = "2.4.7"
 
 [[package]]
-category = "dev"
-description = "pytest: simple powerful testing with Python"
 name = "pytest"
+version = "5.4.1"
+description = "pytest: simple powerful testing with Python"
+category = "dev"
 optional = false
 python-versions = ">=3.5"
-version = "5.4.1"
 
 [package.dependencies]
-atomicwrites = ">=1.0"
+atomicwrites = {version = ">=1.0", markers = "sys_platform == \"win32\""}
 attrs = ">=17.4.0"
-colorama = "*"
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 more-itertools = ">=4.0.0"
 packaging = "*"
 pluggy = ">=0.12,<1.0"
 py = ">=1.5.0"
 wcwidth = "*"
 
-[package.dependencies.importlib-metadata]
-python = "<3.8"
-version = ">=0.12"
-
 [package.extras]
-checkqa-mypy = ["mypy (v0.761)"]
+checkqa-mypy = ["mypy (==v0.761)"]
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
 
 [[package]]
-category = "dev"
-description = "Pytest plugin for measuring coverage."
 name = "pytest-cov"
+version = "2.8.1"
+description = "Pytest plugin for measuring coverage."
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "2.8.1"
 
 [package.dependencies]
 coverage = ">=4.4"
 pytest = ">=3.6"
 
 [package.extras]
-testing = ["fields", "hunter", "process-tests (2.0.2)", "six", "virtualenv"]
+testing = ["fields", "hunter", "process-tests (==2.0.2)", "six", "virtualenv"]
 
 [[package]]
-category = "dev"
-description = "Thin-wrapper around the mock package for easier use with pytest"
 name = "pytest-mock"
+version = "3.0.0"
+description = "Thin-wrapper around the mock package for easier use with pytest"
+category = "dev"
 optional = false
 python-versions = ">=3.5"
-version = "3.0.0"
 
 [package.dependencies]
 pytest = ">=2.7"
@@ -217,69 +209,69 @@ pytest = ">=2.7"
 dev = ["pre-commit", "tox", "pytest-asyncio"]
 
 [[package]]
-category = "dev"
-description = "YAML parser and emitter for Python"
 name = "pyyaml"
+version = "5.3.1"
+description = "YAML parser and emitter for Python"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "5.3.1"
 
 [[package]]
-category = "dev"
-description = "Alternative regular expression module, to replace re."
 name = "regex"
+version = "2020.4.4"
+description = "Alternative regular expression module, to replace re."
+category = "dev"
 optional = false
 python-versions = "*"
-version = "2020.4.4"
 
 [[package]]
-category = "dev"
-description = "Python 2 and 3 compatibility utilities"
 name = "six"
+version = "1.14.0"
+description = "Python 2 and 3 compatibility utilities"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
-version = "1.14.0"
 
 [[package]]
-category = "main"
-description = "Python Library for Tom's Obvious, Minimal Language"
 name = "toml"
-optional = false
-python-versions = "*"
 version = "0.10.0"
+description = "Python Library for Tom's Obvious, Minimal Language"
+category = "main"
+optional = false
+python-versions = "*"
 
 [[package]]
-category = "dev"
-description = "a fork of Python 2 and 3 ast modules with type comment support"
 name = "typed-ast"
-optional = false
-python-versions = "*"
 version = "1.4.1"
-
-[[package]]
+description = "a fork of Python 2 and 3 ast modules with type comment support"
 category = "dev"
-description = "Measures number of Terminal column cells of wide-character codes"
-name = "wcwidth"
 optional = false
 python-versions = "*"
-version = "0.1.9"
 
 [[package]]
+name = "wcwidth"
+version = "0.1.9"
+description = "Measures number of Terminal column cells of wide-character codes"
 category = "dev"
-description = "Backport of pathlib-compatible object wrapper for zip files"
-marker = "python_version < \"3.8\""
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "zipp"
+version = "3.1.0"
+description = "Backport of pathlib-compatible object wrapper for zip files"
+category = "dev"
 optional = false
 python-versions = ">=3.6"
-version = "3.1.0"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "ab7627624a7f34ea86ae4e2a338a094ddfa9ebbe4c376f13851abef8ae72af05"
+lock-version = "1.1"
 python-versions = "^3.6"
+content-hash = "ab7627624a7f34ea86ae4e2a338a094ddfa9ebbe4c376f13851abef8ae72af05"
 
 [metadata.files]
 appdirs = [
@@ -394,6 +386,8 @@ pyyaml = [
     {file = "PyYAML-5.3.1-cp37-cp37m-win_amd64.whl", hash = "sha256:73f099454b799e05e5ab51423c7bcf361c58d3206fa7b0d555426b1f4d9a3eaf"},
     {file = "PyYAML-5.3.1-cp38-cp38-win32.whl", hash = "sha256:06a0d7ba600ce0b2d2fe2e78453a470b5a6e000a985dd4a4e54e436cc36b0e97"},
     {file = "PyYAML-5.3.1-cp38-cp38-win_amd64.whl", hash = "sha256:95f71d2af0ff4227885f7a6605c37fd53d3a106fcab511b8860ecca9fcf400ee"},
+    {file = "PyYAML-5.3.1-cp39-cp39-win32.whl", hash = "sha256:ad9c67312c84def58f3c04504727ca879cb0013b2517c85a9a253f0cb6380c0a"},
+    {file = "PyYAML-5.3.1-cp39-cp39-win_amd64.whl", hash = "sha256:6034f55dab5fea9e53f436aa68fa3ace2634918e8b5994d82f3621c04ff5ed2e"},
     {file = "PyYAML-5.3.1.tar.gz", hash = "sha256:b8eac752c5e14d3eca0e6dd9199cd627518cb5ec06add0de9d32baeee6fe645d"},
 ]
 regex = [
@@ -436,19 +430,28 @@ typed-ast = [
     {file = "typed_ast-1.4.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:269151951236b0f9a6f04015a9004084a5ab0d5f19b57de779f908621e7d8b75"},
     {file = "typed_ast-1.4.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:24995c843eb0ad11a4527b026b4dde3da70e1f2d8806c99b7b4a7cf491612652"},
     {file = "typed_ast-1.4.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:fe460b922ec15dd205595c9b5b99e2f056fd98ae8f9f56b888e7a17dc2b757e7"},
+    {file = "typed_ast-1.4.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:fcf135e17cc74dbfbc05894ebca928ffeb23d9790b3167a674921db19082401f"},
     {file = "typed_ast-1.4.1-cp36-cp36m-win32.whl", hash = "sha256:4e3e5da80ccbebfff202a67bf900d081906c358ccc3d5e3c8aea42fdfdfd51c1"},
     {file = "typed_ast-1.4.1-cp36-cp36m-win_amd64.whl", hash = "sha256:249862707802d40f7f29f6e1aad8d84b5aa9e44552d2cc17384b209f091276aa"},
     {file = "typed_ast-1.4.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8ce678dbaf790dbdb3eba24056d5364fb45944f33553dd5869b7580cdbb83614"},
     {file = "typed_ast-1.4.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:c9e348e02e4d2b4a8b2eedb48210430658df6951fa484e59de33ff773fbd4b41"},
     {file = "typed_ast-1.4.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:bcd3b13b56ea479b3650b82cabd6b5343a625b0ced5429e4ccad28a8973f301b"},
+    {file = "typed_ast-1.4.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:f208eb7aff048f6bea9586e61af041ddf7f9ade7caed625742af423f6bae3298"},
     {file = "typed_ast-1.4.1-cp37-cp37m-win32.whl", hash = "sha256:d5d33e9e7af3b34a40dc05f498939f0ebf187f07c385fd58d591c533ad8562fe"},
     {file = "typed_ast-1.4.1-cp37-cp37m-win_amd64.whl", hash = "sha256:0666aa36131496aed8f7be0410ff974562ab7eeac11ef351def9ea6fa28f6355"},
     {file = "typed_ast-1.4.1-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:d205b1b46085271b4e15f670058ce182bd1199e56b317bf2ec004b6a44f911f6"},
     {file = "typed_ast-1.4.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:6daac9731f172c2a22ade6ed0c00197ee7cc1221aa84cfdf9c31defeb059a907"},
     {file = "typed_ast-1.4.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:498b0f36cc7054c1fead3d7fc59d2150f4d5c6c56ba7fb150c013fbc683a8d2d"},
+    {file = "typed_ast-1.4.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:7e4c9d7658aaa1fc80018593abdf8598bf91325af6af5cce4ce7c73bc45ea53d"},
     {file = "typed_ast-1.4.1-cp38-cp38-win32.whl", hash = "sha256:715ff2f2df46121071622063fc7543d9b1fd19ebfc4f5c8895af64a77a8c852c"},
     {file = "typed_ast-1.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:fc0fea399acb12edbf8a628ba8d2312f583bdbdb3335635db062fa98cf71fca4"},
     {file = "typed_ast-1.4.1-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:d43943ef777f9a1c42bf4e552ba23ac77a6351de620aa9acf64ad54933ad4d34"},
+    {file = "typed_ast-1.4.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:92c325624e304ebf0e025d1224b77dd4e6393f18aab8d829b5b7e04afe9b7a2c"},
+    {file = "typed_ast-1.4.1-cp39-cp39-manylinux1_i686.whl", hash = "sha256:d648b8e3bf2fe648745c8ffcee3db3ff903d0817a01a12dd6a6ea7a8f4889072"},
+    {file = "typed_ast-1.4.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:fac11badff8313e23717f3dada86a15389d0708275bddf766cca67a84ead3e91"},
+    {file = "typed_ast-1.4.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:0d8110d78a5736e16e26213114a38ca35cb15b6515d535413b090bd50951556d"},
+    {file = "typed_ast-1.4.1-cp39-cp39-win32.whl", hash = "sha256:b52ccf7cfe4ce2a1064b18594381bccf4179c2ecf7f513134ec2f993dd4ab395"},
+    {file = "typed_ast-1.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:3742b32cf1c6ef124d57f95be609c473d7ec4c14d0090e5a5e05a15269fb4d0c"},
     {file = "typed_ast-1.4.1.tar.gz", hash = "sha256:8c8aaad94455178e3187ab22c8b01a3837f8ee50e09cf31f1ba129eb293ec30b"},
 ]
 wcwidth = [

--- a/poetry2conda/convert.py
+++ b/poetry2conda/convert.py
@@ -87,6 +87,8 @@ def convert_version(spec_str: str) -> str:
         converted = str(spec)
     elif isinstance(spec, semver.VersionUnion):
         raise ValueError("Complex version constraints are not supported at the moment.")
+    else:
+        raise ValueError("Version constraint could not be parsed.")
     return converted
 
 
@@ -129,7 +131,7 @@ def parse_pyproject_toml(file: TextIO) -> Tuple[Mapping, Mapping]:
     return poetry2conda_config, poetry_config
 
 
-def collect_dependencies(
+def collect_dependencies(  # noqa C901
     poetry_dependencies: Mapping, conda_constraints: Mapping, default_channel: str
 ) -> Tuple[Mapping, Mapping]:
     """ Organize and apply conda constraints to dependencies
@@ -153,7 +155,7 @@ def collect_dependencies(
     # 1. Do a first pass to change pip to conda packages
     for name, conda_dict in conda_constraints.items():
         if name in poetry_dependencies and "git" in poetry_dependencies[name]:
-            poetry_dependencies[name] = conda_dict["version"]
+            poetry_dependencies[name] = conda_dict["version"]  # type: ignore
 
     # 2. Now do the conversion
     for name, constraint in poetry_dependencies.items():
@@ -252,7 +254,7 @@ def to_yaml_string(
         version = version or ""
         deps_str.append(f"  - {name}{version}")
     if pip_dependencies:
-        deps_str.append(f"  - pip:")
+        deps_str.append("  - pip:")
     for name, version in pip_dependencies.items():
         version = version or ""
         deps_str.append(f"    - {name}{version}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,9 +34,14 @@ pytest-mock = "^3.0.0"
 coverage = "^5.1"
 pytest-cov = "^2.8.1"
 black = "^19.10b0"
+flake8 = "^4.0.1"
 
 [tool.poetry.scripts]
 poetry2conda = "poetry2conda.convert:main"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_paths = "./poetry2conda"
 
 [tool.poetry2conda]
 name = 'p2c-env'

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -50,6 +50,54 @@ build-backend = "poetry.masonry.api"
 
 """
 
+SAMPLE_TOML_DEFAULT_CHANNEL_PIP = """\
+[tool.poetry]
+name = "bibimbap"
+version = "1.2.3"
+description = "Delicious korean food"
+authors = ["David Ojeda <david.ojeda@gmail.com>"]
+license = "MIT"
+
+[tool.poetry.dependencies]
+python = "^3.7"
+foo = "^0.2.3"              # Example of a caret requirement whose major version is zero
+bar = "^1.2.3"              # Example of a caret requirement whose major version is not zero
+baz = "~0.4.5"              # Example of a tilde requirement whose major version is zero
+qux = "~1.4.5"              # Example of a tilde requirement whose major version is not zero
+quux = "2.34.5"             # Example of an exact version
+quuz = ">=3.2"              # Example of an inequality
+xyzzy = ">=2.1,<4.2"        # Example of two inequalities
+spinach = "^19.10b0"        # Previously non-working version spec
+pineapple = "1.2.3"         # Will be excluded below
+grault = { git = "https://github.com/organization/repo.git", tag = "v2.7.4"}   # Example of a git package
+pizza = {extras = ["pepperoni"], version = "^1.2.3"}  # Example of a package with extra requirements
+chameleon = { git = "https://github.com/org/repo.git", tag = "v2.3" }
+pudding = { version = "^1.0", optional = true }
+
+[tool.poetry.extras]
+dessert = ["pudding"]
+
+[tool.poetry.dev-dependencies]
+fork = "^1.2"
+
+[tool.poetry2conda]
+name = "bibimbap-env"
+default-channel = "pip"
+
+[tool.poetry2conda.dependencies]
+bar = { channel = "conda-forge" }            # Example of a package on conda-forge
+baz = { channel = "conda" }                  # Example of an explicit conda package
+qux = { name = "thud", channel = "conda" }   # Example of a package that changes names in conda
+xyzzy = { name = "thunk", channel = "pip" }  # Example of a package replacement in pip
+pineapple = { exclude = true }               # Example of a package to exclude from the output
+chameleon = { name = "lizard", channel = "animals", version = "^2.5.4" }  # Example of a package that changes from git to regular conda
+
+[build-system]
+requires = ["poetry>=0.12"]
+build-backend = "poetry.masonry.api"
+
+"""
+
 
 SAMPLE_YAML = """\
 name: bibimbap-env
@@ -111,6 +159,26 @@ dependencies:
 """
 
 
+SAMPLE_YAML_DEFAULT_CHANNEL_PIP = """\
+name: bibimbap-env
+dependencies:
+  - python>=3.7,<4.0
+  - conda-forge::bar>=1.2.3,<2.0.0
+  - baz>=0.4.5,<0.5.0
+  - thud>=1.4.5,<1.5.0
+  - animals::lizard>=2.5.4,<3.0.0
+  - pip
+  - pip:
+    - foo>=0.2.3,<0.3.0
+    - quux==2.34.5
+    - quuz>=3.2
+    - thunk>=2.1,<4.2
+    - spinach>=19.10b0,<20.0
+    - git+https://github.com/organization/repo.git@v2.7.4#egg=grault
+    - pizza>=1.2.3,<2.0.0    # Note that extra requirements are not supported on conda :-(
+"""
+
+
 def test_sample(tmpdir, mocker):
     toml_file = tmpdir / "pyproject.toml"
     yaml_file = tmpdir / "environment.yaml"
@@ -118,6 +186,23 @@ def test_sample(tmpdir, mocker):
     with toml_file.open("w") as fd:
         fd.write(SAMPLE_TOML)
     expected = yaml.safe_load(io.StringIO(SAMPLE_YAML))
+
+    mocker.patch("sys.argv", ["poetry2conda", str(toml_file), str(yaml_file)])
+    main()
+
+    with yaml_file.open("r") as fd:
+        result = yaml.safe_load(fd)
+
+    assert result == expected
+
+
+def test_sample_default_channel_pip(tmpdir, mocker):
+    toml_file = tmpdir / "pyproject.toml"
+    yaml_file = tmpdir / "environment.yaml"
+
+    with toml_file.open("w") as fd:
+        fd.write(SAMPLE_TOML_DEFAULT_CHANNEL_PIP)
+    expected = yaml.safe_load(io.StringIO(SAMPLE_YAML_DEFAULT_CHANNEL_PIP))
 
     mocker.patch("sys.argv", ["poetry2conda", str(toml_file), str(yaml_file)])
     main()

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -1,9 +1,7 @@
 import io
 
 import yaml
-
 from poetry2conda.convert import main
-
 
 # foo, bar, baz, qux, quux, quuz, corge, grault, garply, waldo, fred, plugh, xyzzy, and thud;
 SAMPLE_TOML = """\
@@ -24,6 +22,7 @@ quux = "2.34.5"             # Example of an exact version
 quuz = ">=3.2"              # Example of an inequality
 xyzzy = ">=2.1,<4.2"        # Example of two inequalities
 spinach = "^19.10b0"        # Previously non-working version spec
+pineapple = "1.2.3"         # Will be excluded below
 grault = { git = "https://github.com/organization/repo.git", tag = "v2.7.4"}   # Example of a git package
 pizza = {extras = ["pepperoni"], version = "^1.2.3"}  # Example of a package with extra requirements
 chameleon = { git = "https://github.com/org/repo.git", tag = "v2.3" }
@@ -42,6 +41,7 @@ name = "bibimbap-env"
 bar = { channel = "conda-forge" }            # Example of a package on conda-forge
 baz = { channel = "pip" }                    # Example of a pure pip package
 qux = { name = "thud" }                      # Example of a package that changes names in conda
+pineapple = { exclude = true }               # Example of a package to exclude from the output
 chameleon = { name = "lizard", channel = "animals", version = "^2.5.4" }  # Example of a package that changes from git to regular conda
 
 [build-system]

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -48,7 +48,7 @@ chameleon = { name = "lizard", channel = "animals", version = "^2.5.4" }  # Exam
 requires = ["poetry>=0.12"]
 build-backend = "poetry.masonry.api"
 
-"""
+"""  # noqa E501
 
 SAMPLE_TOML_DEFAULT_CHANNEL_PIP = """\
 [tool.poetry]
@@ -96,7 +96,7 @@ chameleon = { name = "lizard", channel = "animals", version = "^2.5.4" }  # Exam
 requires = ["poetry>=0.12"]
 build-backend = "poetry.masonry.api"
 
-"""
+"""  # noqa E501
 
 
 SAMPLE_YAML = """\


### PR DESCRIPTION
What's changed:
- Add `default-channel` config option (e.g., to be able to specify dependencies pull from `pip` by default)
- Add `exclude` constraint to skip adding specific dependencies to the output altogether

Also:
- Added Flake8 linting & cleaned up warnings
- Update CI to:
  - Test newer Python versions on all platforms
  - Add linting
  - Simplify workflow

To test:
```bash
poetry run pytest
```

To use (until I publish it somewhere):
```bash
poetry run poetry2conda /path/to/pyproject.toml /path/to/environment.yaml
```